### PR TITLE
Feat/add make block script

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -199,12 +199,14 @@ update_theme_info() {
   echo "   Text Domain: fse-boilerplate → $text_domain"
   
   local block_categories="$theme_path/inc/block-categories.php"
+  local make_block="$theme_path/_dev/scripts/make-block.js"
 
   if [ "$DRY_RUN" = true ]; then
     echo "[DRY RUN] Would update theme name to '$display_name' in $style_css"
     echo "[DRY RUN] Would update theme URI to end with '/$theme_slug'"
     echo "[DRY RUN] Would update text domain to '$text_domain'"
     echo "[DRY RUN] Would update block categories slugs and labels in $block_categories"
+    echo "[DRY RUN] Would update make-block script placeholders in $make_block"
   else
     # Update Theme Name (handle both possible current names)
     sed -i "s/^Theme Name: WP Boilerplate FSE/Theme Name: $display_name/" "$style_css"
@@ -225,6 +227,15 @@ update_theme_info() {
       echo "✅ Block categories updated successfully"
     else
       echo "⚠️  block-categories.php not found - skipping"
+    fi
+
+    # Update make-block script
+    if [ -f "$make_block" ]; then
+      sed -i "s/'theme-name'/'$text_domain'/g" "$make_block"
+      sed -i "s/wp-block-theme-name-/wp-block-$text_domain-/g" "$make_block"
+      echo "✅ make-block script updated successfully"
+    else
+      echo "⚠️  make-block.js not found - skipping"
     fi
   fi
 }

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -198,10 +198,13 @@ update_theme_info() {
   echo "   Theme URI: ending with /$theme_slug"
   echo "   Text Domain: fse-boilerplate → $text_domain"
   
+  local block_categories="$theme_path/inc/block-categories.php"
+
   if [ "$DRY_RUN" = true ]; then
     echo "[DRY RUN] Would update theme name to '$display_name' in $style_css"
     echo "[DRY RUN] Would update theme URI to end with '/$theme_slug'"
     echo "[DRY RUN] Would update text domain to '$text_domain'"
+    echo "[DRY RUN] Would update block categories slugs and labels in $block_categories"
   else
     # Update Theme Name (handle both possible current names)
     sed -i "s/^Theme Name: WP Boilerplate FSE/Theme Name: $display_name/" "$style_css"
@@ -214,6 +217,15 @@ update_theme_info() {
     sed -i "s/^Text Domain: .*/Text Domain: $text_domain/" "$style_css"
     
     echo "✅ Theme information updated successfully"
+
+    # Update block categories file
+    if [ -f "$block_categories" ]; then
+      sed -i "s/'theme-name'/'$text_domain'/g" "$block_categories"
+      sed -i "s/'Theme Name'/'$display_name'/g" "$block_categories"
+      echo "✅ Block categories updated successfully"
+    else
+      echo "⚠️  block-categories.php not found - skipping"
+    fi
   fi
 }
 

--- a/wp-content/themes/theme-fse/_dev/package.json
+++ b/wp-content/themes/theme-fse/_dev/package.json
@@ -22,6 +22,7 @@
 	},
 	"scripts": {
 		"dev": "webpack --config webpack.dev.js",
-		"build": "webpack --config webpack.prod.js"
+		"build": "webpack --config webpack.prod.js",
+		"make-block": "node scripts/make-block.js"
 	}
 }

--- a/wp-content/themes/theme-fse/_dev/scripts/make-block.js
+++ b/wp-content/themes/theme-fse/_dev/scripts/make-block.js
@@ -1,0 +1,188 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const args = process.argv.slice(2);
+const blockName = args[0];
+
+if (!blockName) {
+	console.error('❌ Please provide a block name.');
+	console.error('Usage: npm run make-block [block-name]');
+	console.error('');
+	console.error('Example:');
+	console.error('  npm run make-block my-block');
+	process.exit(1);
+}
+
+const blocksDir = path.join(__dirname, '..', 'blocks');
+const blockDir = path.join(blocksDir, blockName);
+
+if (fs.existsSync(blockDir)) {
+	console.error(`❌ Block "${blockName}" already exists.`);
+	process.exit(1);
+}
+
+// Prompt for block type
+const rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout,
+});
+
+console.log('');
+rl.question('Block type?\n  1) Static (saved in post content)\n  2) Dynamic (PHP server-side rendering)\n\nChoose [1-2]: ', (answer) => {
+	const isDynamic = answer === '2';
+
+	createBlock(blockName, isDynamic);
+	rl.close();
+});
+
+function createBlock(blockName, isDynamic) {
+	const blocksDir = path.join(__dirname, '..', 'blocks');
+	const blockDir = path.join(blocksDir, blockName);
+
+	fs.mkdirSync(blockDir, { recursive: true });
+
+	const titleCase = blockName
+		.split('-')
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
+
+	// === [block-name].js (Editor Script) ===
+	const blockJs = `import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import './${blockName}.scss';
+
+import Icon from '../../shared/icon-site.jsx';
+
+registerBlockType('theme-name/${blockName}', {
+	apiVersion: 3,
+	title: __('${titleCase}', 'theme-name'),
+	description: __('Un bloc personnalisé nommé ${blockName}.', 'theme-name'),
+	category: 'theme-name',
+	icon: { src: Icon },
+	keywords: ['${blockName}'],${
+		isDynamic
+			? `
+	render: 'file:./${blockName}.php',`
+			: ''
+	}
+	supports: {
+		align: true,
+		anchor: true,
+		html: false,
+	},
+	attributes: {
+		content: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit: ({ attributes, setAttributes }) => {
+		const blockProps = useBlockProps();
+
+		return (
+			<div {...blockProps}>
+				<RichText
+					tagName="p"
+					value={attributes.content}
+					onChange={(content) => setAttributes({ content })}
+					placeholder={__('Saisir le contenu...', 'theme-name')}
+				/>
+			</div>
+		);
+	},
+${
+	isDynamic
+		? `
+	// Dynamic block - rendered with PHP
+	save: () => null,`
+		: `
+	save: ({ attributes }) => {
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div {...blockProps}>
+				<RichText.Content tagName="p" value={attributes.content} />
+			</div>
+		);
+	},`
+}
+});
+`;
+	fs.writeFileSync(path.join(blockDir, `${blockName}.js`), blockJs);
+
+	// === [block-name]-editor.scss (Editor Styles) ===
+	fs.writeFileSync(
+		path.join(blockDir, `${blockName}-editor.scss`),
+		`.wp-block-theme-name-${blockName} {}
+`
+	);
+
+	// === [block-name].scss (Frontend Styles) ===
+	fs.writeFileSync(
+		path.join(blockDir, `${blockName}.scss`),
+		`.wp-block-theme-name-${blockName} {}
+`
+	);
+
+	// === [block-name]-frontend.js (Frontend JavaScript) ===
+	if (isDynamic) {
+		const frontendJs = `document.addEventListener('DOMContentLoaded', () => {
+	const blocks = document.querySelectorAll('.wp-block-theme-name-${blockName}');
+
+	blocks.forEach((block) => {
+		console.log('${titleCase} block initialized', block);
+	});
+});
+`;
+		fs.writeFileSync(path.join(blockDir, `${blockName}-frontend.js`), frontendJs);
+	}
+
+	// === [block-name].php (PHP render template for dynamic blocks) ===
+	if (isDynamic) {
+		const phpTemplate = `<?php
+/**
+ * Block Name: ${titleCase}
+ * 
+ * @param array $attributes Block attributes.
+ * @param string $content Block content.
+ * @param WP_Block $block Block instance.
+ */
+
+$classes = [];
+
+if (isset($attributes['align'])) {
+	$classes[] = 'align' . $attributes['align'];
+}
+
+if (isset($attributes['className'])) {
+	$classes[] = $attributes['className'];
+}
+
+$wrapper_attributes = get_block_wrapper_attributes([
+	'class' => implode(' ', $classes),
+]);
+?>
+
+<div <?php echo $wrapper_attributes; ?>>
+	<p><?php echo esc_html('${blockName}'); ?></p>
+</div>
+`;
+		fs.writeFileSync(path.join(blockDir, `${blockName}.php`), phpTemplate);
+		console.log('');
+		console.log(`✅ Dynamic block "${blockName}" created in ./blocks/${blockName}`);
+		console.log(`   - ${blockName}.js (editor)`);
+		console.log(`   - ${blockName}.php (render template)`);
+		console.log(`   - ${blockName}.scss (frontend styles)`);
+		console.log(`   - ${blockName}-editor.scss (editor styles)`);
+		console.log(`   - ${blockName}-frontend.js (frontend script)`);
+	} else {
+		console.log('');
+		console.log(`✅ Static block "${blockName}" created in ./blocks/${blockName}`);
+		console.log(`   - ${blockName}.js (editor + save)`);
+		console.log(`   - ${blockName}.scss (frontend styles)`);
+		console.log(`   - ${blockName}-editor.scss (editor styles)`);
+	}
+}

--- a/wp-content/themes/theme-fse/inc/block-categories.php
+++ b/wp-content/themes/theme-fse/inc/block-categories.php
@@ -1,0 +1,50 @@
+<?php
+
+if ( ! defined('ABSPATH') ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Add custom category for patterns in the Block Editor
+ * 
+ * @return void
+ */
+function studio_register_patterns_categories()
+{
+    $icon = file_exists(get_template_directory() . '/dist/img/icon-site.svg')
+        ? file_get_contents(get_template_directory() . '/dist/img/icon-site.svg')
+        : 'star-filled';
+
+    register_block_pattern_category(
+        'theme-name',
+        array(
+            'label' => __('Theme Name', 'theme-name'),
+            'icon'  => $icon,
+        )
+    );
+}
+add_filter('init', 'studio_register_patterns_categories');
+
+/**
+ * Add custom category for blocks in the Block Editor
+ * 
+ * @return void
+ */
+function studio_register_blocks_categories($categories, $post)
+{
+    $icon = file_exists(get_template_directory() . '/dist/img/icon-site.svg')
+        ? file_get_contents(get_template_directory() . '/dist/img/icon-site.svg')
+        : 'star-filled';
+
+    return array_merge(
+        array(
+            array(
+                'slug'  => 'theme-name',
+                'title' => __('Theme Name', 'theme-name'),
+                'icon'  => $icon,
+            ),
+        ),
+        $categories
+    );
+}
+add_filter('block_categories_all', 'studio_register_blocks_categories', 10, 2);


### PR DESCRIPTION
## Description

To quickly create a new block in CLI, I added `make-block` script. It allows developers to create a new custom Gutenberg block using `npm run make-block block-name` in `/_dev/`. Developers are also prompted to chose between static or dynamic block.

## Related Issue

No related issue.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced