### PR TITLE
fix: Setup - Fixed auth.json.example filename mismatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 			"@test"
 		],
 		"post-install-cmd": [
-			"@php -r \"if (!file_exists('auth.json') && file_exists('auth.example.json')) { copy('auth.example.json', 'auth.json'); echo 'Created auth.json from example. Please update with your credentials.\\n'; }\""
+			"@php -r \"if (!file_exists('auth.json') && file_exists('auth.json.example')) { copy('auth.json.example', 'auth.json'); echo 'Created auth.json from example. Please update with your credentials.\\n'; }\""
 		]
 	},
 	"extra": {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,7 +75,7 @@ export ACF_PRO_LICENSE="your_license_key"
 
 **3. auth.json file:**
 ```bash
-cp auth.example.json auth.json
+cp auth.json.example auth.json
 ```
 Edit `auth.json` and set your key as the password:
 ```json


### PR DESCRIPTION
## Description

The `composer.json` post-install-cmd was looking for `auth.example.json`, but the actual file in the repo is `auth.json.example`. This caused the post-install hook to silently fail on a fresh `composer install`, meaning `auth.json` was never auto-created from the example file.

The same wrong filename appeared in `docs/setup.md` in the manual copy instruction.

## Related Issue

Part of the repo cleanup plan — PR 1 of 5.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced

## Additional Notes

Two files changed, two identical strings updated:
- `composer.json:63` — post-install-cmd `file_exists` + `copy` calls
- `docs/setup.md:78` — manual `cp` instruction in the ACF Pro setup section