### PR TITLE
docs: Skills - Added no-auto-merge guardrail to open-pr skill

### DIFF
--- a/.claude/skills/open-pr.md
+++ b/.claude/skills/open-pr.md
@@ -41,3 +41,4 @@ Use `gh pr create` with an **English** body following `.github/PULL_REQUEST_TEMP
 - **Never force-push** to any branch.
 - **Never rewrite history** (`git rebase -i`, `git reset --hard`, `git commit --amend`) on `main`, `staging`, or `development`.
 - **Never push directly** to `main` or `staging` — always use a feature branch and PR.
+- **Never merge a PR** — the user is the sole reviewer and merger. Stop after `gh pr create` and report the PR URL.


### PR DESCRIPTION
## Description

Adds an explicit guardrail to the `open-pr` skill preventing Claude from merging PRs autonomously. The user is the sole reviewer and merger on this repository.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [x] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced — N/A

## Screenshots

N/A

## Additional Notes

One-line addition to `.claude/skills/open-pr.md` guardrails section.