### PR TITLE
refactor: Skills - Renamed to follow scope-what.md convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,7 @@ Default: **French**. Switch to English when I write in English.
 
 ## Pointers
 
-- **Commits and PRs**: use the `open-pr` skill.
-- **PHPStan level bumps**: use the `bump-phpstan-level` skill.
+- **Commits and PRs**: use the `git-open-pr` skill.
+- **PHPStan level bumps**: use the `phpstan-bump` skill.
 - **Block authoring**: `.claude/BLOCKS.md`.
 - **Naming, security, i18n, git details**: `.claude/CONVENTIONS.md`.

--- a/.claude/skills/docs-sync.md
+++ b/.claude/skills/docs-sync.md
@@ -1,5 +1,5 @@
 ---
-name: sync-docs
+name: docs-sync
 description: Invoke automatically when the conversation adds or modifies Claude Code automation — hooks or permissions in .claude/settings.json, rules under .claude/rules/, agents under .claude/agents/, skills under .claude/skills/, slash commands under .claude/commands/, MCP servers in .mcp.json, or the team docs themselves (.claude/CLAUDE.md, ARCHITECTURE.md, BLOCKS.md, CONVENTIONS.md). Audits the team docs against the live state of .claude/ and proposes updates. Does not auto-apply edits — reports drift and proposes them for user approval.
 ---
 

--- a/.claude/skills/git-open-pr.md
+++ b/.claude/skills/git-open-pr.md
@@ -1,5 +1,5 @@
 ---
-name: open-pr
+name: git-open-pr
 description: Commit, push, and open a GitHub PR on request. Follow semantic commit format and the PULL_REQUEST_TEMPLATE.md. Invoke whenever the user asks to commit, push, create a PR, or "push this".
 ---
 

--- a/.claude/skills/phpstan-bump.md
+++ b/.claude/skills/phpstan-bump.md
@@ -1,5 +1,5 @@
 ---
-name: bump-phpstan-level
+name: phpstan-bump
 description: Raise the PHPStan analysis level by one, triage new errors (real bugs vs WP false positives), fix or suppress them, and commit. Invoke when the user asks to bump PHPStan or raise the analysis level.
 ---
 
@@ -30,7 +30,7 @@ These are pre-existing; do not treat them as regressions from a level bump:
      $value = get_field( 'my_field' ); // @phpstan-ignore-line — ACF returns mixed; narrowed by context
      ```
 4. **Confirm green**: `composer ci` (lint + stan + test must all pass, 0 errors).
-5. **Commit** using the `open-pr` skill conventions:
+5. **Commit** using the `git-open-pr` skill conventions:
    ```
    chore: Tooling - Raised PHPStan to level <N>
    ```


### PR DESCRIPTION
## Description

Renames three skill files to consistently follow the `[scope]-[what].md` naming convention already used by `a11y-links-buttons.md`, `block-audit.md`, and `i18n-audit.md`.

| Before | After |
|---|---|
| `open-pr.md` | `git-open-pr.md` |
| `bump-phpstan-level.md` | `phpstan-bump.md` |
| `sync-docs.md` | `docs-sync.md` |

Also updates the `name:` frontmatter field in each file, the cross-reference inside `phpstan-bump.md`, and the Pointers section in `CLAUDE.md`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced — N/A

## Screenshots

N/A

## Additional Notes

No behaviour change — renames only.