### PR TITLE
fix: PHP - Fixed phpcs warnings and security issues across inc/ files

### DIFF
--- a/wp-content/themes/theme-fse/inc/block-settings.php
+++ b/wp-content/themes/theme-fse/inc/block-settings.php
@@ -14,7 +14,8 @@ function sv_boilerplate_remove_block_style_variations() {
 		'studio-script-unregister-style-variations',
 		get_template_directory_uri() . '/assets/js/editor/unregister-style-variations.js',
 		array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),
-		'1.0'
+		wp_get_theme()->get( 'Version' ),
+		true
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'sv_boilerplate_remove_block_style_variations' );

--- a/wp-content/themes/theme-fse/inc/media-uploads.php
+++ b/wp-content/themes/theme-fse/inc/media-uploads.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Allow SVG images to be uploaded securely
  *
+ * @param array $mimes Allowed MIME types.
  * @return array
  */
 function sv_boilerplate_allow_svg_uploads( $mimes ) {
@@ -29,16 +30,17 @@ function sv_boilerplate_sanitize_svg_file( $file ) {
 		pathinfo( $file, PATHINFO_EXTENSION ) === 'svg' &&
 		current_user_can( 'manage_options' )
 	) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local upload path, not a remote URL.
 		$svg = file_get_contents( $file );
 
-		// Remove script/style/foreignObject tags
+		// Remove script/style/foreignObject tags.
 		$svg = preg_replace( '/<(script|style|foreignObject).*?<\/\1>/is', '', $svg );
 
-		// Strip all on* attributes (like onload, onclick)
+		// Strip all on* attributes (like onload, onclick).
 		$svg = preg_replace( '/ on\w+="[^"]*"/i', '', $svg );
 		$svg = preg_replace( "/ on\w+='[^']*'/i", '', $svg );
 
-		// Save the sanitized SVG back to file
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- local upload path, writing sanitized content back.
 		file_put_contents( $file, $svg );
 	}
 }
@@ -52,6 +54,9 @@ add_action(
 
 /**
  * Allow WebP images to be uploaded securely
+ *
+ * @param array $mimes Allowed MIME types.
+ * @return array
  */
 function sv_boilerplate_allow_webp_uploads( $mimes ) {
 	if ( current_user_can( 'manage_options' ) ) {
@@ -68,10 +73,10 @@ add_filter( 'upload_mimes', 'sv_boilerplate_allow_webp_uploads' );
  * @param array  $data     File type data.
  * @param string $file     Full path to the file.
  * @param string $filename File name.
- * @param array  $mimes    Allowed mime types.
+ * @param mixed  $_mimes   Allowed mime types (unused — required by WP hook signature).
  * @return array
  */
-function sv_boilerplate_fix_webp_filetype( $data, $file, $filename, $mimes ) {
+function sv_boilerplate_fix_webp_filetype( $data, $file, $filename, $_mimes ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 	if ( false !== strpos( $filename, '.webp' ) ) {
 		$data['ext']  = 'webp';
 		$data['type'] = 'image/webp';

--- a/wp-content/themes/theme-fse/inc/post-types.php
+++ b/wp-content/themes/theme-fse/inc/post-types.php
@@ -5,81 +5,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Register Custom Post Types
+ * Register Custom Post Types and Taxonomies.
  *
+ * Use the `wp-create-post-type` and `wp-create-taxonomy` Claude Code skills
+ * to scaffold new types with the correct labels, args, and conventions.
  */
 function sv_boilerplate_register_post_types() {
-	// CPT "CPT"
-	$labels = array(
-		'name'              => _x( 'CPTs', 'Post Type General Name', 'studioval-boilerplate' ),
-		'singular_name'     => _x( 'CPT', 'Post Type Singular Name', 'studioval-boilerplate' ),
-		'menu_name'         => __( 'CPTs', 'studioval-boilerplate' ),
-		'name_admin_bar'    => __( 'CPT', 'studioval-boilerplate' ),
-		'archives'          => __( 'CPT Archives', 'studioval-boilerplate' ),
-		'attributes'        => __( 'CPT Attributes', 'studioval-boilerplate' ),
-		'parent_item_colon' => __( 'Parent CPT:', 'studioval-boilerplate' ),
-		'all_items'         => __( 'All CPTs', 'studioval-boilerplate' ),
-		'add_new_item'      => __( 'Add New CPT', 'studioval-boilerplate' ),
-		'add_new'           => __( 'Add New', 'studioval-boilerplate' ),
-		'new_item'          => __( 'New CPT', 'studioval-boilerplate' ),
-		'edit_item'         => __( 'Edit CPT', 'studioval-boilerplate' ),
-		'update_item'       => __( 'Update CPT', 'studioval-boilerplate' ),
-		'view_item'         => __( 'View CPT', 'studioval-boilerplate' ),
-		'view_items'        => __( 'View CPTs', 'studioval-boilerplate' ),
-		'search_items'      => __( 'Search CPTs', 'studioval-boilerplate' ),
-	);
-
-	$args = array(
-		'label'               => __( 'CPT', 'studioval-boilerplate' ),
-		'description'         => __( 'Custom Post Type Description', 'studioval-boilerplate' ),
-		'labels'              => $labels,
-		'supports'            => array( 'title', 'editor', 'thumbnail', 'revisions' ),
-		'hierarchical'        => false,
-		'public'              => true,
-		'show_ui'             => true,
-		'show_in_menu'        => true,
-		'menu_position'       => 5,
-		'menu_icon'           => 'dashicons-admin-post',
-		'show_in_admin_bar'   => true,
-		'show_in_nav_menus'   => true,
-		'can_export'          => true,
-		'has_archive'         => true,
-		'exclude_from_search' => false,
-		'publicly_queryable'  => true,
-		'capability_type'     => 'post',
-	);
-
-	register_post_type( 'cpt', $args );
-
-	// Taxonomy "CPT Category"
-	$labels = array(
-		'name'                       => _x( 'CPT Categories', 'Taxonomy General Name', 'studioval-boilerplate' ),
-		'singular_name'              => _x( 'CPT Category', 'Taxonomy Singular Name', 'studioval-boilerplate' ),
-		'menu_name'                  => __( 'CPT Categories', 'studioval-boilerplate' ),
-		'all_items'                  => __( 'All CPT Categories', 'studioval-boilerplate' ),
-		'parent_item'                => __( 'Parent CPT Category', 'studioval-boilerplate' ),
-		'parent_item_colon'          => __( 'Parent CPT Category:', 'studioval-boilerplate' ),
-		'new_item_name'              => __( 'New CPT Category Name', 'studioval-boilerplate' ),
-		'add_new_item'               => __( 'Add New CPT Category', 'studioval-boilerplate' ),
-		'edit_item'                  => __( 'Edit CPT Category', 'studioval-boilerplate' ),
-		'update_item'                => __( 'Update CPT Category', 'studioval-boilerplate' ),
-		'view_item'                  => __( 'View CPT Category', 'studioval-boilerplate' ),
-		'separate_items_with_commas' => __( 'Separate CPT categories with commas', 'studioval-boilerplate' ),
-		'add_or_remove_items'        => __( 'Add or remove CPT categories', 'studioval-boilerplate' ),
-		'choose_from_most_used'      => __( 'Choose from the most used CPT categories', 'studioval-boilerplate' ),
-	);
-
-	$args = array(
-		'labels'            => $labels,
-		'hierarchical'      => true,
-		'public'            => true,
-		'show_ui'           => true,
-		'show_admin_column' => true,
-		'query_var'         => true,
-		'rewrite'           => array( 'slug' => 'cpt-category' ),
-		'show_in_rest'      => true,
-	);
-
-	register_taxonomy( 'cpt_category', 'cpt', $args );
+	// Register your custom post types here.
 }
 add_action( 'init', 'sv_boilerplate_register_post_types' );

--- a/wp-content/themes/theme-fse/inc/security.php
+++ b/wp-content/themes/theme-fse/inc/security.php
@@ -29,32 +29,46 @@ if ( is_admin() && ! defined( 'DISALLOW_FILE_EDIT' ) ) {
  * @return string
  */
 function sv_boilerplate_hide_login_errors( $error ) {
+	unset( $error );
 	return __( 'Login failed. Please try again.', 'studioval-boilerplate' );
 }
 add_filter( 'login_errors', 'sv_boilerplate_hide_login_errors' );
 
 /**
- * Disable directory browsing via .htaccess fallback.
+ * Disable directory browsing by writing "Options -Indexes" to .htaccess.
+ * Uses insert_with_markers() so the block is idempotent and clearly delimited.
  *
  * @return void
  */
 function sv_boilerplate_disable_directory_browsing() {
 	$htaccess = ABSPATH . '.htaccess';
 
-	if ( is_writable( $htaccess ) && strpos( file_get_contents( $htaccess ), 'Options -Indexes' ) === false ) {
-		file_put_contents( $htaccess, "Options -Indexes\n", FILE_APPEND );
+	if ( ! file_exists( $htaccess ) ) {
+		return;
 	}
+
+	if ( ! function_exists( 'insert_with_markers' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+	}
+
+	$existing = extract_from_markers( $htaccess, 'sv-no-indexes' );
+
+	if ( in_array( 'Options -Indexes', $existing, true ) ) {
+		return;
+	}
+
+	insert_with_markers( $htaccess, 'sv-no-indexes', array( 'Options -Indexes' ) );
 }
 add_action( 'init', 'sv_boilerplate_disable_directory_browsing' );
 
 /**
- * Disable author archive scans
+ * Disable author archive scans to prevent user enumeration.
  *
  * @return void
  */
 function sv_boilerplate_disable_author_archive_scans() {
 	if ( is_author() && ! is_user_logged_in() ) {
-		wp_redirect( home_url() );
+		wp_safe_redirect( home_url() );
 		exit;
 	}
 }

--- a/wp-content/themes/theme-fse/inc/user-capabilities.php
+++ b/wp-content/themes/theme-fse/inc/user-capabilities.php
@@ -7,17 +7,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Allow every Block Editor features for administrators
  *
- * @return WP_Theme_JSON
+ * @param WP_Theme_JSON_Data $theme_json The theme JSON data.
+ * @return WP_Theme_JSON_Data
  */
 function sv_boilerplate_grant_admin_block_editor_capabilities( $theme_json ) {
 	if ( ! current_user_can( 'edit_theme_options' ) ) {
 		return $theme_json;
 	}
 
-	$new_data = json_decode(
-		file_get_contents( get_theme_file_path( 'admin-caps.json' ) ),
-		true
-	);
+	$caps_file = get_theme_file_path( 'admin-caps.json' );
+
+	if ( ! file_exists( $caps_file ) ) {
+		return $theme_json;
+	}
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local theme file, not a remote URL.
+	$new_data = json_decode( file_get_contents( $caps_file ), true );
+
+	if ( ! is_array( $new_data ) ) {
+		return $theme_json;
+	}
 
 	return $theme_json->update_with( $new_data );
 }


### PR DESCRIPTION
## Description

Resolves all phpcs warnings and security issues flagged in the production audit.

**security.php**
- `wp_redirect` → `wp_safe_redirect` in author archive handler
- Replaced `file_get_contents` / `file_put_contents` / `is_writable` with `insert_with_markers()` (WP native API) for `.htaccess` manipulation — idempotent, clearly delimited
- Added `unset( $error )` to fix unused parameter warning on required `login_errors` hook signature

**user-capabilities.php**
- Added `file_exists()` guard before reading `admin-caps.json`
- Added `is_array()` guard before calling `update_with()`
- Added `phpcs:ignore` with justification for `file_get_contents` on a local theme file (not a remote URL)
- Added proper `@param` type in PHPDoc

**media-uploads.php**
- Added `phpcs:ignore` with justification for `file_get_contents` / `file_put_contents` on local upload paths
- Renamed unused `$mimes` → `$_mimes` with inline `phpcs:ignore` comment explaining it is a required WP hook parameter
- Added `@param` docblock to all functions

**block-settings.php**
- Added explicit `$in_footer = true` and `wp_get_theme()->get( 'Version' )` to `wp_enqueue_script` in `sv_boilerplate_remove_block_style_variations()`

**post-types.php**
- Removed placeholder CPT (`cpt`) and taxonomy (`cpt_category`) — they registered on every install
- Left an empty scaffold function with a comment pointing to the `wp-create-post-type` and `wp-create-taxonomy` skills

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [x] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced — N/A

## Screenshots

N/A

## Additional Notes

`composer ci` passes with 8 warnings remaining (all pre-existing and documented in CLAUDE.md Known pitfalls): `block-bindings.php` unused WP hook params, `dashboard.php` commented-out code, `theme-setup.php` commented-out code, and the intentionally empty `_dev/blocks/block/block.php` scaffold.