### PR TITLE
docs: Skills - Added wp-create-post-type, taxonomy, options-page, meta-box

### DIFF
--- a/.claude/skills/wp-create-meta-box.md
+++ b/.claude/skills/wp-create-meta-box.md
@@ -1,0 +1,138 @@
+---
+name: wp-create-meta-box
+description: Scaffold a native WordPress meta box with custom fields using the Meta Box API and register_meta(). No ACF required. Invoke when the user asks to add custom fields, a meta box, or post metadata to a post type.
+---
+
+# wp-create-meta-box skill
+
+## When to invoke
+
+- User asks to add custom fields or a meta box to a post type.
+- User wants to store per-post metadata (e.g. subtitle, external URL, event date).
+- User wants to replace an ACF field group with native WP code.
+
+## Conventions
+
+- Create a dedicated file: `wp-content/themes/theme-fse/inc/meta-{slug}.php`.
+- Register it via the glob in `functions.php` — no manual require needed.
+- Function prefix: `sv_boilerplate_`. Meta key prefix: `_sv_boilerplate_`.
+- Text-domain: `studioval-boilerplate`.
+- ABSPATH guard at the top.
+- Always verify nonce with `wp_verify_nonce()` on save.
+- Always check `current_user_can( 'edit_post', $post_id )` on save.
+- Sanitize on save, escape on output.
+- Use `register_meta()` with `show_in_rest: true` for block editor / REST API access.
+
+## Template
+
+```php
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register post meta for REST API and block editor access.
+ */
+function sv_boilerplate_register_{slug}_meta() {
+    register_post_meta(
+        '{post-type}',
+        '_sv_boilerplate_{field}',
+        array(
+            'type'              => 'string',
+            'single'            => true,
+            'show_in_rest'      => true,
+            'sanitize_callback' => 'sanitize_text_field',
+            'auth_callback'     => function () {
+                return current_user_can( 'edit_posts' );
+            },
+        )
+    );
+}
+add_action( 'init', 'sv_boilerplate_register_{slug}_meta' );
+
+/**
+ * Add the meta box.
+ */
+function sv_boilerplate_add_{slug}_meta_box() {
+    add_meta_box(
+        'sv_boilerplate_{slug}',
+        __( '{Label}', 'studioval-boilerplate' ),
+        'sv_boilerplate_render_{slug}_meta_box',
+        '{post-type}',
+        'normal',
+        'default'
+    );
+}
+add_action( 'add_meta_boxes', 'sv_boilerplate_add_{slug}_meta_box' );
+
+/**
+ * Render the meta box HTML.
+ *
+ * @param WP_Post $post Current post object.
+ */
+function sv_boilerplate_render_{slug}_meta_box( $post ) {
+    wp_nonce_field( 'sv_boilerplate_{slug}_save', 'sv_boilerplate_{slug}_nonce' );
+
+    $value = get_post_meta( $post->ID, '_sv_boilerplate_{field}', true );
+    ?>
+    <p>
+        <label for="sv_boilerplate_{field}"><?php esc_html_e( '{Field Label}', 'studioval-boilerplate' ); ?></label><br>
+        <input
+            type="text"
+            id="sv_boilerplate_{field}"
+            name="sv_boilerplate_{field}"
+            value="<?php echo esc_attr( $value ); ?>"
+            class="widefat"
+        >
+    </p>
+    <?php
+}
+
+/**
+ * Save meta box data.
+ *
+ * @param int $post_id Post ID.
+ */
+function sv_boilerplate_save_{slug}_meta( $post_id ) {
+    if (
+        ! isset( $_POST['sv_boilerplate_{slug}_nonce'] ) ||
+        ! wp_verify_nonce( sanitize_key( $_POST['sv_boilerplate_{slug}_nonce'] ), 'sv_boilerplate_{slug}_save' )
+    ) {
+        return;
+    }
+
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+        return;
+    }
+
+    if ( isset( $_POST['sv_boilerplate_{field}'] ) ) {
+        update_post_meta(
+            $post_id,
+            '_sv_boilerplate_{field}',
+            sanitize_text_field( wp_unslash( $_POST['sv_boilerplate_{field}'] ) )
+        );
+    }
+}
+add_action( 'save_post', 'sv_boilerplate_save_{slug}_meta' );
+```
+
+## Reading the meta value in a template
+
+```php
+$value = get_post_meta( get_the_ID(), '_sv_boilerplate_{field}', true );
+if ( $value ) {
+    echo esc_html( $value );
+}
+```
+
+## Checklist after adding
+
+1. Run `composer lint` — verify nonce, capability check, sanitize, and escape are present.
+2. Test save/retrieve in wp-admin edit screen.
+3. If the field needs to be editable in the block editor sidebar, use `useEntityProp` in JS with the registered meta key.

--- a/.claude/skills/wp-create-options-page.md
+++ b/.claude/skills/wp-create-options-page.md
@@ -1,0 +1,132 @@
+---
+name: wp-create-options-page
+description: Scaffold a native WordPress admin options page using the Settings API. No ACF required. Invoke when the user asks to add an options page, settings page, or theme settings panel.
+---
+
+# wp-create-options-page skill
+
+## When to invoke
+
+- User asks to add an options page, settings page, or admin panel.
+- User wants to store theme-level settings (e.g. social links, contact info, API keys).
+
+## Conventions
+
+- Create a dedicated file: `wp-content/themes/theme-fse/inc/options-{slug}.php`.
+- Register it in `functions.php` via the existing glob — no manual require needed.
+- Function prefix: `sv_boilerplate_`. Option name prefix: `sv_boilerplate_`.
+- Text-domain: `studioval-boilerplate`.
+- ABSPATH guard at the top of the new file.
+- Nonce with `check_admin_referer()` on save.
+- Sanitize every input before storing with `update_option()`.
+- Always call `settings_errors()` inside the page callback for feedback display.
+
+## Template
+
+```php
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register the {Label} settings page.
+ */
+function sv_boilerplate_register_{slug}_page() {
+    add_theme_page(
+        __( '{Label} Settings', 'studioval-boilerplate' ),
+        __( '{Label}', 'studioval-boilerplate' ),
+        'manage_options',
+        'sv-{slug}',
+        'sv_boilerplate_render_{slug}_page'
+    );
+}
+add_action( 'admin_menu', 'sv_boilerplate_register_{slug}_page' );
+
+/**
+ * Register settings, sections, and fields.
+ */
+function sv_boilerplate_init_{slug}_settings() {
+    register_setting(
+        'sv_boilerplate_{slug}_group',
+        'sv_boilerplate_{slug}_options',
+        array( 'sanitize_callback' => 'sv_boilerplate_sanitize_{slug}_options' )
+    );
+
+    add_settings_section(
+        'sv_boilerplate_{slug}_section',
+        __( '{Section Label}', 'studioval-boilerplate' ),
+        '__return_false',
+        'sv-{slug}'
+    );
+
+    add_settings_field(
+        'sv_boilerplate_{slug}_{field}',
+        __( '{Field Label}', 'studioval-boilerplate' ),
+        'sv_boilerplate_render_{slug}_{field}_field',
+        'sv-{slug}',
+        'sv_boilerplate_{slug}_section'
+    );
+}
+add_action( 'admin_init', 'sv_boilerplate_init_{slug}_settings' );
+
+/**
+ * Sanitize options on save.
+ *
+ * @param array $input Raw posted values.
+ * @return array
+ */
+function sv_boilerplate_sanitize_{slug}_options( $input ) {
+    $clean = array();
+    $clean['{field}'] = isset( $input['{field}'] ) ? sanitize_text_field( $input['{field}'] ) : '';
+    return $clean;
+}
+
+/**
+ * Render the {field} input field.
+ */
+function sv_boilerplate_render_{slug}_{field}_field() {
+    $options = get_option( 'sv_boilerplate_{slug}_options', array() );
+    $value   = isset( $options['{field}'] ) ? esc_attr( $options['{field}'] ) : '';
+    printf(
+        '<input type="text" name="sv_boilerplate_{slug}_options[{field}]" value="%s" class="regular-text">',
+        $value
+    );
+}
+
+/**
+ * Render the settings page.
+ */
+function sv_boilerplate_render_{slug}_page() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+        <?php settings_errors(); ?>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'sv_boilerplate_{slug}_group' );
+            do_settings_sections( 'sv-{slug}' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <?php
+}
+```
+
+## Reading a saved option
+
+```php
+$options = get_option( 'sv_boilerplate_{slug}_options', array() );
+$value   = $options['{field}'] ?? '';
+```
+
+## Checklist after adding
+
+1. Flush the options cache if testing: `ddev wp cache flush`.
+2. Run `composer lint` — verify ABSPATH guard, escaping, and nonce are in place.
+3. Test the form saves and retrieves correctly in wp-admin.

--- a/.claude/skills/wp-create-post-type.md
+++ b/.claude/skills/wp-create-post-type.md
@@ -1,0 +1,70 @@
+---
+name: wp-create-post-type
+description: Scaffold a native WordPress Custom Post Type registration in inc/post-types.php. No ACF required. Invoke when the user asks to add a CPT, custom post type, or register a new content type.
+---
+
+# wp-create-post-type skill
+
+## When to invoke
+
+- User asks to add a CPT / custom post type.
+- User asks to register a new content type (e.g. "Portfolio", "Testimonials", "Events").
+
+## Conventions
+
+- All CPTs go in `wp-content/themes/theme-fse/inc/post-types.php`, inside `sv_boilerplate_register_post_types()`.
+- Function and hook prefix: `sv_boilerplate_` (substituted by `bin/setup.sh`).
+- Text-domain: `studioval-boilerplate`.
+- Always set `show_in_rest: true` for block editor compatibility.
+- Use `rewrite: array( 'slug' => 'your-slug' )` for clean URLs.
+
+## Template
+
+```php
+// CPT "{Label}"
+$labels = array(
+    'name'               => _x( '{Labels}', 'Post Type General Name', 'studioval-boilerplate' ),
+    'singular_name'      => _x( '{Label}', 'Post Type Singular Name', 'studioval-boilerplate' ),
+    'menu_name'          => __( '{Labels}', 'studioval-boilerplate' ),
+    'name_admin_bar'     => __( '{Label}', 'studioval-boilerplate' ),
+    'all_items'          => __( 'All {Labels}', 'studioval-boilerplate' ),
+    'add_new_item'       => __( 'Add New {Label}', 'studioval-boilerplate' ),
+    'add_new'            => __( 'Add New', 'studioval-boilerplate' ),
+    'new_item'           => __( 'New {Label}', 'studioval-boilerplate' ),
+    'edit_item'          => __( 'Edit {Label}', 'studioval-boilerplate' ),
+    'update_item'        => __( 'Update {Label}', 'studioval-boilerplate' ),
+    'view_item'          => __( 'View {Label}', 'studioval-boilerplate' ),
+    'search_items'       => __( 'Search {Labels}', 'studioval-boilerplate' ),
+    'not_found'          => __( 'No {label} found', 'studioval-boilerplate' ),
+    'not_found_in_trash' => __( 'No {label} found in trash', 'studioval-boilerplate' ),
+);
+
+$args = array(
+    'label'               => __( '{Label}', 'studioval-boilerplate' ),
+    'labels'              => $labels,
+    'supports'            => array( 'title', 'editor', 'thumbnail', 'revisions' ),
+    'hierarchical'        => false,
+    'public'              => true,
+    'show_ui'             => true,
+    'show_in_menu'        => true,
+    'menu_position'       => 5,
+    'menu_icon'           => 'dashicons-admin-post',
+    'show_in_admin_bar'   => true,
+    'show_in_nav_menus'   => true,
+    'show_in_rest'        => true,
+    'has_archive'         => true,
+    'rewrite'             => array( 'slug' => '{slug}' ),
+    'publicly_queryable'  => true,
+    'capability_type'     => 'post',
+);
+
+register_post_type( '{slug}', $args );
+```
+
+## Checklist after adding
+
+1. Flush rewrite rules: `ddev wp rewrite flush` or deactivate/reactivate the theme.
+2. If the CPT needs custom fields, use the `wp-create-meta-box` skill.
+3. If the CPT needs a custom taxonomy, use the `wp-create-taxonomy` skill.
+4. Add templates for the CPT archive/single if needed (`templates/archive-{slug}.html`, `templates/single-{slug}.html`).
+5. Run `composer lint` — no new errors expected.

--- a/.claude/skills/wp-create-taxonomy.md
+++ b/.claude/skills/wp-create-taxonomy.md
@@ -1,0 +1,56 @@
+---
+name: wp-create-taxonomy
+description: Scaffold a native WordPress taxonomy registration in inc/post-types.php. No ACF required. Invoke when the user asks to add a taxonomy, category, or tag to a post type.
+---
+
+# wp-create-taxonomy skill
+
+## When to invoke
+
+- User asks to add a taxonomy, category, or tag to a CPT.
+- User asks to create a custom classification (e.g. "Portfolio Category", "Event Type").
+
+## Conventions
+
+- All taxonomies go in `wp-content/themes/theme-fse/inc/post-types.php`, inside `sv_boilerplate_register_post_types()`, after the CPT they belong to.
+- Function and hook prefix: `sv_boilerplate_`.
+- Text-domain: `studioval-boilerplate`.
+- Always set `show_in_rest: true` for block editor compatibility.
+- Hierarchical (`true`) = category-like. Non-hierarchical (`false`) = tag-like.
+
+## Template
+
+```php
+// Taxonomy "{Label}" for "{cpt-slug}"
+$tax_labels = array(
+    'name'                       => _x( '{Labels}', 'Taxonomy General Name', 'studioval-boilerplate' ),
+    'singular_name'              => _x( '{Label}', 'Taxonomy Singular Name', 'studioval-boilerplate' ),
+    'menu_name'                  => __( '{Labels}', 'studioval-boilerplate' ),
+    'all_items'                  => __( 'All {Labels}', 'studioval-boilerplate' ),
+    'new_item_name'              => __( 'New {Label} Name', 'studioval-boilerplate' ),
+    'add_new_item'               => __( 'Add New {Label}', 'studioval-boilerplate' ),
+    'edit_item'                  => __( 'Edit {Label}', 'studioval-boilerplate' ),
+    'update_item'                => __( 'Update {Label}', 'studioval-boilerplate' ),
+    'view_item'                  => __( 'View {Label}', 'studioval-boilerplate' ),
+    'not_found'                  => __( 'No {label} found', 'studioval-boilerplate' ),
+);
+
+$tax_args = array(
+    'labels'            => $tax_labels,
+    'hierarchical'      => true,
+    'public'            => true,
+    'show_ui'           => true,
+    'show_admin_column' => true,
+    'show_in_rest'      => true,
+    'query_var'         => true,
+    'rewrite'           => array( 'slug' => '{tax-slug}' ),
+);
+
+register_taxonomy( '{tax-slug}', '{cpt-slug}', $tax_args );
+```
+
+## Checklist after adding
+
+1. Flush rewrite rules: `ddev wp rewrite flush`.
+2. If the taxonomy is standalone (not tied to a CPT), pass `'post'` or an array of post types as the second argument.
+3. Run `composer lint` — no new errors expected.


### PR DESCRIPTION
## Description

Adds four new Claude Code skills for scaffolding native WordPress content structures without ACF.

| Skill | Invoke when... |
|-------|----------------|
| `wp-create-post-type` | Adding a CPT / custom post type |
| `wp-create-taxonomy` | Adding a taxonomy or custom classification |
| `wp-create-options-page` | Adding an admin settings page |
| `wp-create-meta-box` | Adding custom fields / replacing an ACF field group |

Each skill includes a complete PHP template, project conventions (prefix, text-domain, escaping, nonce), and a post-creation checklist.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [x] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced — N/A

## Screenshots

N/A

## Additional Notes

Skills only — no PHP changes. All templates in the skills follow the project security rules (ABSPATH, escaping, nonces, `$wpdb->prepare`).