### PR TITLE
fix: Theme - Restore @babel/preset-react for JSX compilation

### DIFF
--- a/wp-content/themes/theme-fse/_dev/babel.config.json
+++ b/wp-content/themes/theme-fse/_dev/babel.config.json
@@ -1,3 +1,13 @@
 {
-	"presets": [["@babel/preset-env", { "modules": false }]]
+	"presets": [
+		["@babel/preset-env", { "modules": false }],
+		[
+			"@babel/preset-react",
+			{
+				"runtime": "classic",
+				"pragma": "wp.element.createElement",
+				"pragmaFrag": "wp.element.Fragment"
+			}
+		]
+	]
 }

--- a/wp-content/themes/theme-fse/_dev/package-lock.json
+++ b/wp-content/themes/theme-fse/_dev/package-lock.json
@@ -7,6 +7,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.27.4",
 				"@babel/preset-env": "^7.27.2",
+				"@babel/preset-react": "^7.27.1",
 				"@wordpress/eslint-plugin": "^22.10.0",
 				"@wordpress/stylelint-config": "^23.18.0",
 				"autoprefixer": "^10.4.21",
@@ -1470,6 +1471,75 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/plugin-transform-react-display-name": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+			"integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+			"integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-syntax-jsx": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-jsx-development": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+			"integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-transform-react-jsx": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-react-pure-annotations": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+			"integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
 		"node_modules/@babel/plugin-transform-regenerator": {
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
@@ -1820,6 +1890,27 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/@babel/preset-react": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.28.5.tgz",
+			"integrity": "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-transform-react-display-name": "^7.28.0",
+				"@babel/plugin-transform-react-jsx": "^7.27.1",
+				"@babel/plugin-transform-react-jsx-development": "^7.27.1",
+				"@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/preset-typescript": {

--- a/wp-content/themes/theme-fse/_dev/package.json
+++ b/wp-content/themes/theme-fse/_dev/package.json
@@ -2,6 +2,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.27.4",
 		"@babel/preset-env": "^7.27.2",
+		"@babel/preset-react": "^7.27.1",
 		"@wordpress/eslint-plugin": "^22.10.0",
 		"@wordpress/stylelint-config": "^23.18.0",
 		"autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Description

CI build was failing with:

```
SyntaxError: ...ThemeOptionPage.jsx: Support for the experimental syntax 'jsx' isn't currently enabled (84:3)
```

Root cause — commit `300db78` removed `@babel/preset-react` from the theme's `babel.config.json` under the (incorrect) assumption that the theme had no JSX. In fact, `_dev/admin/ThemeOptionPage.jsx` and `_dev/admin/components/MyCard.jsx` (introduced by `26dffd4`, merged via PR #76) require it.

Fixes:
- Restored `@babel/preset-react` in `babel.config.json` with the previous classic runtime (`pragma: wp.element.createElement`, `pragmaFrag: wp.element.Fragment`) so JSX targets the global `wp.element` runtime that WordPress enqueues.
- Added `@babel/preset-react` to the theme's `devDependencies` (the original problem the previous commit was trying to solve was that the package was missing from devDependencies — addressed properly here by installing it rather than removing the preset).
- Updated `package-lock.json` accordingly.

Verified locally: `npm run build` exits 0 and emits `js/admin.bundle.js`.

## Related Issue

Closes #

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (Local by Flywheel)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced

## Screenshots

N/A — build/tooling fix, no UI change.

## Additional Notes

The diff in `package-lock.json` looks large because npm rewrote a number of integrity hashes when the new dependency tree was resolved. The only direct addition is `@babel/preset-react` and its transitive deps (4 packages reported by npm).