### PR TITLE
fix: Setup - Fixed DDEV detection and wired up --theme override

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -367,8 +367,33 @@ update_plugin_lint_configs() {
   fi
 }
 
+# Patch the repo-level .gitignore so the renamed plugin folder stays
+# version-controlled. The plugins glob (wp-content/plugins/*) ignores everything
+# and the boilerplate is re-included by its old name only; without this the
+# renamed folder would silently drop out of git.
+update_plugin_gitignore() {
+  local target_root="$1"
+  local plugin_slug="$2"
+  local gitignore="$target_root/.gitignore"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "[DRY RUN] Would update .gitignore whitelist for plugin slug $plugin_slug"
+    return 0
+  fi
+
+  if [ -f "$gitignore" ]; then
+    # Covers both the `!…/studioval-plugin-boilerplate/` un-ignore line and the
+    # `…/studioval-plugin-boilerplate/node_modules/` re-ignore line. No-op when
+    # the slug is unchanged (replaces the path with itself).
+    sed_inplace "s|wp-content/plugins/studioval-plugin-boilerplate/|wp-content/plugins/$plugin_slug/|g" "$gitignore"
+    log_success ".gitignore updated for plugin"
+    increment_success
+  fi
+}
+
 # Top-level orchestrator. Renames folder + main file, then runs identifier
-# substitution and lint-config updates. No-op if user keeps the default slug.
+# substitution plus lint-config and .gitignore updates. No-op if user keeps the
+# default slug.
 update_plugin_boilerplate() {
   local plugins_dir="$1"
   local source_slug="studioval-plugin-boilerplate"
@@ -401,6 +426,7 @@ update_plugin_boilerplate() {
 
   update_plugin_info "$target_path" "$target_slug"
   update_plugin_lint_configs "$target_root" "$target_slug"
+  update_plugin_gitignore "$target_root" "$target_slug"
 }
 
 # Function to update GitHub workflow files with the correct theme name

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -502,7 +502,7 @@ cd "$WP_PATH"
 
 if [[ "$(uname -s)" == *"MINGW"* || "$(uname -s)" == *"NT"* ]]; then
   WP="cmd //c wp"
-elif command -v ddev &>/dev/null && ddev status 2>/dev/null | grep -q "running"; then
+elif command -v ddev &>/dev/null && ddev describe -j 2>/dev/null | grep -q '"status":"running"'; then
   WP="ddev wp"
 else
   WP="wp"
@@ -558,11 +558,16 @@ fi
 # ========== THEME AUTO-DETECT & RENAME ==========
 log_step "🎨 THEME SETUP"
 
-# 1) Auto-detect the one source theme folder
+# 1) Determine the source theme folder: an explicit --theme= override wins,
+#    otherwise auto-detect by scanning wp-content/themes/.
 SLUGS=()
-while IFS= read -r slug; do
-  SLUGS+=("$slug")
-done < <(find "$WP_CONTENT/themes" -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
+if [ -n "$THEME_SLUG" ]; then
+  SLUGS=("$THEME_SLUG")
+else
+  while IFS= read -r slug; do
+    SLUGS+=("$slug")
+  done < <(find "$WP_CONTENT/themes" -maxdepth 1 -mindepth 1 -type d -exec basename {} \;)
+fi
 if    [ ${#SLUGS[@]} -eq 0 ]; then
   log_info "No theme folder found in $WP_CONTENT/themes/"
   log_info "Checking if setup has already been completed..."
@@ -592,7 +597,11 @@ if    [ ${#SLUGS[@]} -eq 0 ]; then
   fi
 elif  [ ${#SLUGS[@]} -eq 1 ]; then
   THEME_SRC="${SLUGS[0]}"
-  log_info "Auto-detected source theme: $THEME_SRC"
+  if [ -n "$THEME_SLUG" ]; then
+    log_info "Using provided source theme: $THEME_SRC"
+  else
+    log_info "Auto-detected source theme: $THEME_SRC"
+  fi
 else
   echo "🎨 Multiple themes found:"
   for s in "${SLUGS[@]}"; do echo "  – $s"; done


### PR DESCRIPTION
## Description

Three robustness fixes to `bin/setup.sh`.

### 1. DDEV detection (the reported bug)

`bin/setup.sh` failed with a misleading **"WP-CLI introuvable / lance ddev start"** error even when DDEV was running.

**Root cause:** DDEV ≥ 1.25 renders the running state as `OK` in `ddev status` (it used to print `running`). The probe `ddev status | grep "running"` therefore never matched, the script fell back to a global `wp` binary — which isn't installed — and aborted at the WP-CLI check, *before* doing any work.

**Fix:** detect DDEV via `ddev describe -j | grep '"status":"running"'`, the stable JSON source already used elsewhere in the script.

### 2. `--theme=` flag wired up

The `--theme=` flag was assigned but never used (dead code), despite `--help` advertising it. It now actually overrides source-theme detection, making the script runnable non-interactively even when several theme folders are present.

### 3. `.gitignore` whitelist patched on plugin rename

The plugins glob (`wp-content/plugins/*`) ignores everything and re-includes the boilerplate by its old name only. The rename step moved the folder but left the whitelist pointing at `studioval-plugin-boilerplate`, so a renamed plugin silently dropped out of version control. New `update_plugin_gitignore()` repoints the un-ignore + `node_modules` lines at the new slug. *(Hit in #105, fixed by hand there.)*

### Verification

- DDEV detection now resolves to `ddev wp`.
- Full `--dry-run` completes end-to-end: exit 0, 0 errors, 0 warnings.
- No error when WordPress core is already installed.
- `--theme=theme-fse` bypasses the prompt even with 4 theme folders present.
- `.gitignore` sed patches both whitelist lines, leaves other plugins untouched.
- `bash -n bin/setup.sh` passes.

## Related Issue

Closes #

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [ ] 🔒 Security fix
- [ ] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions
- [x] I have tested my changes locally
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified (N/A — shell only)
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard (N/A — shell only)
- [x] Documentation updated if new patterns were introduced (N/A)

## Screenshots

N/A — shell script only.

## Additional Notes

Shell-only change (`bin/setup.sh`). Fixes 1 and 2 stand alone; fix 3 makes future installs handle the `.gitignore` whitelist automatically (which had to be done manually in #105).
