### PR TITLE
ci: Deploy - Exclude internal tooling and dev config from FTP uploads

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,14 +29,37 @@ jobs:
                   server-dir: ${{ secrets.FTP_SERVER_DIR }}
                   timeout: 60000
                   security: strict
+                  # Root deploy ships only runtime root content (e.g. .well-known/security.txt).
+                  # Everything listed below is VCS / CI / dev tooling and must never reach a live host.
                   exclude: |
                       wp-content/**
                       .git/**
                       .github/**
+                      .claude/**
+                      .ddev/**
                       node_modules/**
                       vendor/**
+                      bin/**
+                      docs/**
+                      tests/**
+                      CHANGELOG.md
+                      README.md
+                      LICENSE
+                      composer.json
+                      composer.lock
+                      phpcs.xml.dist
+                      phpstan.neon.dist
+                      phpunit.xml.dist
+                      wp-cli.yml
+                      .editorconfig
+                      .env.example
+                      .gitignore
+                      .markdownlint.json
+                      .nvmrc
 
             - name: Deploy Theme
+              # _dev/ is intentionally shipped with the theme (project requirement).
+              # node_modules/ and .git* are excluded by the action's default ignore list.
               uses: SamKirkland/FTP-Deploy-Action@v4.4.0
               with:
                   server: ${{ secrets.FTP_HOST }}
@@ -61,3 +84,12 @@ jobs:
                   server-dir: ${{ secrets.FTP_SERVER_DIR }}/wp-content/plugins/
                   timeout: 60000
                   security: strict
+                  # Plugin source (src/, webpack, configs) is intentionally kept,
+                  # mirroring the theme's _dev/. Only deps, logs, OS junk and DB dumps are dropped.
+                  exclude: |
+                      node_modules/**
+                      vendor/**
+                      *.log
+                      .DS_Store
+                      Thumbs.db
+                      *.sql

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,14 +29,37 @@ jobs:
                   server-dir: ${{ secrets.FTP_SERVER_DIR }}
                   timeout: 60000
                   security: strict
+                  # Root deploy ships only runtime root content (e.g. .well-known/security.txt).
+                  # Everything listed below is VCS / CI / dev tooling and must never reach a live host.
                   exclude: |
                       wp-content/**
                       .git/**
                       .github/**
+                      .claude/**
+                      .ddev/**
                       node_modules/**
                       vendor/**
+                      bin/**
+                      docs/**
+                      tests/**
+                      CHANGELOG.md
+                      README.md
+                      LICENSE
+                      composer.json
+                      composer.lock
+                      phpcs.xml.dist
+                      phpstan.neon.dist
+                      phpunit.xml.dist
+                      wp-cli.yml
+                      .editorconfig
+                      .env.example
+                      .gitignore
+                      .markdownlint.json
+                      .nvmrc
 
             - name: Deploy Theme
+              # _dev/ is intentionally shipped with the theme (project requirement).
+              # node_modules/ and .git* are excluded by the action's default ignore list.
               uses: SamKirkland/FTP-Deploy-Action@v4.4.0
               with:
                   server: ${{ secrets.FTP_HOST }}
@@ -61,6 +84,8 @@ jobs:
                   server-dir: ${{ secrets.FTP_SERVER_DIR }}/wp-content/plugins/
                   timeout: 60000
                   security: strict
+                  # Plugin source (src/, webpack, configs) is intentionally kept,
+                  # mirroring the theme's _dev/. Only deps, logs, OS junk and DB dumps are dropped.
                   exclude: |
                       node_modules/**
                       vendor/**


### PR DESCRIPTION
## Description

Tightens the FTP deploy workflows so that only runtime files reach the live host. Previously the **Deploy Root Files** step uploaded the entire repo root minus a short ignore list, which meant internal/dev artefacts were published to the web root — most notably the whole `.claude/` directory (CLAUDE.md, rules, hooks, `settings.json`, team docs), plus `.ddev/`, `docs/`, `tests/`, `bin/` and all root-level tooling configs (`composer.*`, `php{cs,stan,unit}.*.dist`, `wp-cli.yml`, dotfiles…).

Changes (applied to both `deploy-production.yml` and `deploy-staging.yml`):

- **Root step** — extended the `exclude:` list to drop `.claude/**`, `.ddev/**`, `bin/**`, `docs/**`, `tests/**` and every root-level dev/CI config file. Net effect: the root step now ships only genuine runtime content (`.well-known/security.txt`), which is intentionally kept.
- **Plugins step** — production had **no** `exclude` at all; it now uses the same list as staging (`node_modules`, `vendor`, `*.log`, `.DS_Store`, `Thumbs.db`, `*.sql`). Production and staging are now aligned.
- **Theme step** — left functionally unchanged: `_dev/` is intentionally still deployed (project requirement). Added a clarifying comment.

### Deliberately not changed
- No global `**/.git*` exclusion was added to the Theme/Plugins steps — that would have dropped the `.gitkeep` markers that create the empty `languages/` and `assets/icons/` directories on the server.
- Plugin sources (`src/`, webpack, lint configs) are kept, mirroring the theme's `_dev/`.
- The deploy workflows run no `install`/`build` step, so `node_modules`/`vendor` never exist on the runner; those excludes are defensive.

## Related Issue

Closes #

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [ ] 📝 Documentation
- [ ] 🔒 Security fix
- [x] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally (YAML validated with `yaml.safe_load`)
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified (N/A — CI only)
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`) (N/A — no PHP)
- [x] New PHP files include the `ABSPATH` security guard (N/A — no PHP)
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced

## Screenshots

N/A — CI configuration only.

## Additional Notes

Affects the FTP deploy workflows only; both are guarded off on this template repo (`if: github.repository != 'valentin-grenier/wp-boilerplate-fse'`), so the new exclusions take effect on client projects generated via `bin/setup.sh`. If reviewers would rather also strip plugin sources (`src/`, webpack, lint configs) from deployments, that can be added — current behaviour mirrors the kept theme `_dev/`.