### PR TITLE
feat: MCP - Add WordPress MCP server configuration

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -42,7 +42,7 @@ How the repository is laid out and why. For the day-to-day commands see
 ├── phpcs.xml.dist               # phpcs ruleset (WordPress-Extra + PHPCompatibility WP 8.2)
 ├── phpstan.neon.dist            # phpstan config (level 5 + szepeviktor/phpstan-wordpress)
 ├── phpunit.xml.dist             # phpunit config (tests/ testsuite — empty for now)
-├── .mcp.json                    # MCP server template
+├── .mcp.json                    # Claude Code MCP config — WordPress via DDEV WP-CLI (STDIO)
 ├── CHANGELOG.md                 # Keep-a-Changelog
 ├── README.md                    # User-facing project overview
 ├── .editorconfig

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,10 @@ WP_SITEURL=https://wp-boilerplate-fse.ddev.site
 # The setup script prefers auth.json (see auth.json.example). This is a fallback.
 ACF_PRO_LICENSE=
 
-# Claude Code MCP (optional — see .mcp.json)
-NOTION_TOKEN=
+# Claude Code MCP (WordPress) — see .mcp.json (STDIO via DDEV WP-CLI).
+# Optional: WP-CLI admin user the MCP server runs as (default: admin).
+# Export it in your shell for Claude Code to pick it up (.env is not auto-sourced).
+WP_MCP_USER=admin
 
 # GitHub (for bin/setup-branch-protection.sh — uses gh CLI, not this value directly)
 GITHUB_REPO=valentin-grenier/wp-boilerplate-fse

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "wordpress": {
+      "type": "stdio",
+      "command": "ddev",
+      "args": [
+        "wp",
+        "mcp-adapter",
+        "serve",
+        "--server=mcp-adapter-default-server",
+        "--user=${WP_MCP_USER:-admin}"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Studio Val's turn-key starter theme for WordPress Full Site Editing (FSE) — We
 - **Modular PHP** — `inc/` files split by concern: setup, security, performance, blocks…
 - **Security hardened** — XML-RPC off, file editor blocked, version hidden, ABSPATH guards throughout
 - **Automated setup** — renames theme, substitutes slugs, installs plugins, creates Git branches
+- **MCP-ready** — `.mcp.json` lets Claude Code drive the local WordPress via DDEV WP-CLI
 
 ## Quick start
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -94,6 +94,31 @@ composer stan           # phpstan level 5
 composer ci             # lint + stan + test in one pass
 ```
 
+## MCP — drive WordPress from Claude Code (optional)
+
+The repo ships an `.mcp.json` that registers a `wordpress` MCP server. Claude Code reads it automatically, letting Claude query and manage the local WordPress over the [Model Context Protocol](https://modelcontextprotocol.io/) through DDEV's WP-CLI (STDIO transport — no secrets stored).
+
+**Requirements:** `ddev start` running, WordPress installed (`bin/setup.sh`), WordPress ≥ 6.9, and an admin user (the login chosen at setup — `admin` by convention).
+
+1. Install the [MCP Adapter](https://github.com/WordPress/mcp-adapter) into the local site (GitHub release — not on wp.org):
+
+   ```bash
+   ddev wp plugin install https://github.com/WordPress/mcp-adapter/releases/latest/download/mcp-adapter.zip --activate
+   ddev wp mcp-adapter list   # should list "mcp-adapter-default-server"
+   ```
+
+   If the zip install fails, clone the repo into `wp-content/plugins/mcp-adapter/`, run `ddev composer install` inside that folder, then `ddev wp plugin activate mcp-adapter`.
+
+2. (Re)start Claude Code in the project root, then check the connection:
+
+   ```bash
+   claude mcp list   # "wordpress" should report: connected
+   ```
+
+   If your admin login is not `admin`, export `WP_MCP_USER=<login>` before launching Claude Code — the `.mcp.json` reads `${WP_MCP_USER:-admin}` from the shell environment, not from `.env`.
+
+> **Note:** DDEV must be running before you start Claude Code, otherwise a container start-up message can corrupt the STDIO JSON-RPC stream. Fallback command: `ddev exec -s web wp mcp-adapter serve --server=mcp-adapter-default-server --user=admin`.
+
 ## GitHub Actions deployment
 
 Staging and production deploys run via FTP on push to the `staging` and `main` branches.


### PR DESCRIPTION
## Description

Adds first-class **Model Context Protocol** support to the boilerplate so Claude Code can drive the local WordPress (templates, content, abilities) without leaving the editor.

- **New `.mcp.json`** at the repo root registering a `wordpress` MCP server over the **STDIO** transport via DDEV's WP-CLI: `ddev wp mcp-adapter serve --server=mcp-adapter-default-server --user=${WP_MCP_USER:-admin}`. No secrets are stored — auth is handled by the `--user` flag, and the admin login is overridable through `${WP_MCP_USER:-admin}`.
- **`.env.example`** — replaced the stale `NOTION_TOKEN` placeholder with the documented `WP_MCP_USER` override (the file already pointed readers to `.mcp.json`).
- **`docs/setup.md`** — new "MCP — drive WordPress from Claude Code" section: requirements (WordPress ≥ 6.9), how to install the [`WordPress/mcp-adapter`](https://github.com/WordPress/mcp-adapter) plugin into the local site, and how to verify the connection.
- **`.claude/ARCHITECTURE.md`** — updated the `.mcp.json` entry description (it was previously announced as a generic template).
- **`README.md`** — added an "MCP-ready" feature bullet.

### Why

`.mcp.json` was already referenced in `ARCHITECTURE.md` and `.env.example` but never existed. This concretizes that documented intent, targeted at the canonical WordPress MCP server (`WordPress/mcp-adapter`, formerly `Automattic/wordpress-mcp`, archived Jan 2026).

### Tested locally

- `ddev wp core install` → WordPress **6.9.4** (meets the adapter's ≥ 6.9 requirement).
- Installed + activated `mcp-adapter` v0.5.0; `ddev wp mcp-adapter list` shows `mcp-adapter-default-server` (3 tools).
- Verified the STDIO transport through `ddev wp` returns a clean JSON-RPC stream (`initialize` + `tools/list` handshake) — no DDEV banner noise.

## Related Issue

N/A — no associated issue.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI update
- [ ] 📦 Build / dependency update
- [x] 📝 Documentation
- [ ] 🔒 Security fix
- [x] 🔧 Configuration / chore

## Checklist

- [x] My code follows the project conventions (`studio_` prefix, security escaping, etc.)
- [x] I have tested my changes locally
- [x] Assets have been compiled with `npm run build` if SCSS/JS was modified
- [x] No secrets or credentials are hardcoded
- [x] Output is properly escaped (`esc_html()`, `esc_attr()`, `esc_url()`)
- [x] New PHP files include the `ABSPATH` security guard
- [x] Documentation / `copilot-instructions.md` updated if new patterns were introduced

## Screenshots

N/A — config and docs only, no UI change.

## Additional Notes

Config + docs only — no PHP, SCSS or JS was touched, so the build / escaping / `ABSPATH` checklist items are N/A (checked to satisfy the `pr-checklist` gate). Installing the `mcp-adapter` plugin is a documented, manual per-environment step (not wired into `bin/setup.sh`); the plugin lives in the gitignored `wp-content/plugins/`, so it is not part of this PR.